### PR TITLE
Add support for connection string abbreviations

### DIFF
--- a/src/IntegrationTests/ITODBCConnection/test_odbc_connection.cpp
+++ b/src/IntegrationTests/ITODBCConnection/test_odbc_connection.cpp
@@ -272,6 +272,44 @@ TEST(TestSqlDriverConnect, ConnStringAbbrevsUIDPWD) {
     EXPECT_TRUE(SQL_SUCCEEDED(ret));
 }
 
+TEST(TestSqlDriverConnect, ConnStringAbbrevsServer) {
+    std::wstring abbrev_str =
+    use_ssl ? L"Driver={Elasticsearch ODBC};"
+              L"server=https://localhost;port=9200;"
+              L"user=admin;password=admin;auth=BASIC;useSSL="
+              L"1;hostnameVerification=0;logLevel=0;logOutput=C:\\;"
+              L"responseTimeout=10;"
+            : L"Driver={Elasticsearch ODBC};"
+              L"server=localhost;port=9200;"
+              L"user=admin;password=admin;auth=BASIC;useSSL="
+              L"0;hostnameVerification=0;logLevel=0;logOutput=C:\\;"
+              L"responseTimeout=10;";
+
+    SQLRETURN ret;
+    ExecuteSqlDriverConnect((SQLTCHAR*)abbrev_str.c_str(),
+                            SQL_DRIVER_NOPROMPT, &ret);
+    EXPECT_TRUE(SQL_SUCCEEDED(ret));
+}
+
+TEST(TestSqlDriverConnect, ConnStringAbbrevsServerUIDPWD) {
+    std::wstring abbrev_str =
+    use_ssl ? L"Driver={Elasticsearch ODBC};"
+              L"server=https://localhost;port=9200;"
+              L"UID=admin;PWD=admin;auth=BASIC;useSSL="
+              L"1;hostnameVerification=0;logLevel=0;logOutput=C:\\;"
+              L"responseTimeout=10;"
+            : L"Driver={Elasticsearch ODBC};"
+              L"server=localhost;port=9200;"
+              L"UID=admin;PWD=admin;auth=BASIC;useSSL="
+              L"0;hostnameVerification=0;logLevel=0;logOutput=C:\\;"
+              L"responseTimeout=10;";
+
+    SQLRETURN ret;
+    ExecuteSqlDriverConnect((SQLTCHAR*)abbrev_str.c_str(),
+                            SQL_DRIVER_NOPROMPT, &ret);
+    EXPECT_TRUE(SQL_SUCCEEDED(ret));
+}
+
 TEST(TestSqlDriverConnect, Timeout1Second) {
     std::wstring one_second_timeout = 
     use_ssl ? L"Driver={Elasticsearch ODBC};"

--- a/src/IntegrationTests/ITODBCConnection/test_odbc_connection.cpp
+++ b/src/IntegrationTests/ITODBCConnection/test_odbc_connection.cpp
@@ -215,6 +215,63 @@ TEST(TestSqlDriverConnect, UnsupportedKeyword) {
     EXPECT_EQ(SQL_ERROR, ret);
 }
 
+TEST(TestSqlDriverConnect, ConnStringAbbrevsUID) {
+    std::wstring abbrev_str =
+    use_ssl ? L"Driver={Elasticsearch ODBC};"
+              L"host=https://localhost;port=9200;"
+              L"UID=admin;password=admin;auth=BASIC;useSSL="
+              L"1;hostnameVerification=0;logLevel=0;logOutput=C:\\;"
+              L"responseTimeout=10;"
+            : L"Driver={Elasticsearch ODBC};"
+              L"host=localhost;port=9200;"
+              L"UID=admin;password=admin;auth=BASIC;useSSL="
+              L"0;hostnameVerification=0;logLevel=0;logOutput=C:\\;"
+              L"responseTimeout=10;";
+
+    SQLRETURN ret;
+    ExecuteSqlDriverConnect((SQLTCHAR*)abbrev_str.c_str(),
+                            SQL_DRIVER_NOPROMPT, &ret);
+    EXPECT_TRUE(SQL_SUCCEEDED(ret));
+}
+
+TEST(TestSqlDriverConnect, ConnStringAbbrevsPWD) {
+    std::wstring abbrev_str =
+    use_ssl ? L"Driver={Elasticsearch ODBC};"
+              L"host=https://localhost;port=9200;"
+              L"user=admin;PWD=admin;auth=BASIC;useSSL="
+              L"1;hostnameVerification=0;logLevel=0;logOutput=C:\\;"
+              L"responseTimeout=10;"
+            : L"Driver={Elasticsearch ODBC};"
+              L"host=localhost;port=9200;"
+              L"user=admin;PWD=admin;auth=BASIC;useSSL="
+              L"0;hostnameVerification=0;logLevel=0;logOutput=C:\\;"
+              L"responseTimeout=10;";
+
+    SQLRETURN ret;
+    ExecuteSqlDriverConnect((SQLTCHAR*)abbrev_str.c_str(),
+                            SQL_DRIVER_NOPROMPT, &ret);
+    EXPECT_TRUE(SQL_SUCCEEDED(ret));
+}
+
+TEST(TestSqlDriverConnect, ConnStringAbbrevsUIDPWD) {
+    std::wstring abbrev_str =
+    use_ssl ? L"Driver={Elasticsearch ODBC};"
+              L"host=https://localhost;port=9200;"
+              L"UID=admin;PWD=admin;auth=BASIC;useSSL="
+              L"1;hostnameVerification=0;logLevel=0;logOutput=C:\\;"
+              L"responseTimeout=10;"
+            : L"Driver={Elasticsearch ODBC};"
+              L"host=localhost;port=9200;"
+              L"UID=admin;PWD=admin;auth=BASIC;useSSL="
+              L"0;hostnameVerification=0;logLevel=0;logOutput=C:\\;"
+              L"responseTimeout=10;";
+
+    SQLRETURN ret;
+    ExecuteSqlDriverConnect((SQLTCHAR*)abbrev_str.c_str(),
+                            SQL_DRIVER_NOPROMPT, &ret);
+    EXPECT_TRUE(SQL_SUCCEEDED(ret));
+}
+
 TEST(TestSqlDriverConnect, Timeout1Second) {
     std::wstring one_second_timeout = 
     use_ssl ? L"Driver={Elasticsearch ODBC};"

--- a/src/elasticodbc/dlg_specific.c
+++ b/src/elasticodbc/dlg_specific.c
@@ -140,9 +140,8 @@ BOOL copyConnAttributes(ConnInfo *ci, const char *attribute,
         STRCPY_FIXED(ci->dsn, value);
     else if (stricmp(attribute, "driver") == 0)
         STRCPY_FIXED(ci->drivername, value);
-    else if (stricmp(attribute, INI_SERVER) == 0)
-        STRCPY_FIXED(ci->server, value);
-    else if (stricmp(attribute, INI_HOST) == 0)
+    else if ((stricmp(attribute, INI_HOST) == 0)
+             || (stricmp(attribute, INI_SERVER) == 0))
         STRCPY_FIXED(ci->server, value);
     else if (stricmp(attribute, INI_PORT) == 0)
         STRCPY_FIXED(ci->port, value);

--- a/src/elasticodbc/dlg_specific.c
+++ b/src/elasticodbc/dlg_specific.c
@@ -144,9 +144,11 @@ BOOL copyConnAttributes(ConnInfo *ci, const char *attribute,
         STRCPY_FIXED(ci->server, value);
     else if (stricmp(attribute, INI_PORT) == 0)
         STRCPY_FIXED(ci->port, value);
-    else if (stricmp(attribute, INI_USERNAME) == 0)
+    else if ((stricmp(attribute, INI_USERNAME) == 0)
+             || (stricmp(attribute, INI_USERNAME_ABBR) == 0))
         STRCPY_FIXED(ci->username, value);
-    else if (stricmp(attribute, INI_PASSWORD) == 0) {
+    else if ((stricmp(attribute, INI_PASSWORD) == 0)
+             || (stricmp(attribute, INI_PASSWORD_ABBR) == 0)) {
         ci->password = decode_or_remove_braces(value);
 #ifndef FORCE_PASSWORDE_DISPLAY
         MYLOG(0, "key='%s' value='xxxxxxxx'\n", attribute);
@@ -269,7 +271,15 @@ void getDSNinfo(ConnInfo *ci, const char *configDrvrname) {
                                    sizeof(temp), ODBC_INI)
         > 0)
         STRCPY_FIXED(ci->username, temp);
+    if (SQLGetPrivateProfileString(DSN, INI_USERNAME_ABBR, NULL_STRING, temp,
+                                   sizeof(temp), ODBC_INI)
+        > 0)
+        STRCPY_FIXED(ci->username, temp);
     if (SQLGetPrivateProfileString(DSN, INI_PASSWORD, NULL_STRING, temp,
+                                   sizeof(temp), ODBC_INI)
+        > 0)
+        ci->password = decode(temp);
+    if (SQLGetPrivateProfileString(DSN, INI_PASSWORD_ABBR, NULL_STRING, temp,
                                    sizeof(temp), ODBC_INI)
         > 0)
         ci->password = decode(temp);

--- a/src/elasticodbc/dlg_specific.c
+++ b/src/elasticodbc/dlg_specific.c
@@ -91,7 +91,7 @@ void makeConnectString(char *connect_string, const ConnInfo *ci, UWORD len) {
     /* fundamental info */
     nlen = MAX_CONNECT_STRING;
     olen = snprintf(connect_string, nlen,
-             "%s=%s;" INI_SERVER "=%s;" INI_PORT "=%s;" INI_USERNAME
+             "%s=%s;" INI_HOST "=%s;" INI_PORT "=%s;" INI_USERNAME
              "=%s;" INI_PASSWORD "=%s;" INI_AUTH_MODE "=%s;" INI_REGION
              "=%s;" INI_SSL_USE "=%d;" INI_SSL_HOST_VERIFY "=%d;" INI_LOG_LEVEL
              "=%d;" INI_LOG_OUTPUT "=%s;" INI_TIMEOUT "=%s;",
@@ -141,6 +141,8 @@ BOOL copyConnAttributes(ConnInfo *ci, const char *attribute,
     else if (stricmp(attribute, "driver") == 0)
         STRCPY_FIXED(ci->drivername, value);
     else if (stricmp(attribute, INI_SERVER) == 0)
+        STRCPY_FIXED(ci->server, value);
+    else if (stricmp(attribute, INI_HOST) == 0)
         STRCPY_FIXED(ci->server, value);
     else if (stricmp(attribute, INI_PORT) == 0)
         STRCPY_FIXED(ci->port, value);
@@ -263,6 +265,10 @@ void getDSNinfo(ConnInfo *ci, const char *configDrvrname) {
                                    sizeof(temp), ODBC_INI)
         > 0)
         STRCPY_FIXED(ci->server, temp);
+    if (SQLGetPrivateProfileString(DSN, INI_HOST, NULL_STRING, temp,
+                                   sizeof(temp), ODBC_INI)
+        > 0)
+        STRCPY_FIXED(ci->server, temp);
     if (SQLGetPrivateProfileString(DSN, INI_PORT, NULL_STRING, temp,
                                    sizeof(temp), ODBC_INI)
         > 0)
@@ -334,7 +340,7 @@ void writeDSNinfo(const ConnInfo *ci) {
     const char *DSN = ci->dsn;
     char encoded_item[MEDIUM_REGISTRY_LEN], temp[SMALL_REGISTRY_LEN];
     
-    SQLWritePrivateProfileString(DSN, INI_SERVER, ci->server, ODBC_INI);
+    SQLWritePrivateProfileString(DSN, INI_HOST, ci->server, ODBC_INI);
     SQLWritePrivateProfileString(DSN, INI_PORT, ci->port, ODBC_INI);
     SQLWritePrivateProfileString(DSN, INI_USERNAME, ci->username, ODBC_INI);
     encode(ci->password, encoded_item, sizeof(encoded_item));

--- a/src/elasticodbc/dlg_specific.h
+++ b/src/elasticodbc/dlg_specific.h
@@ -50,8 +50,9 @@ extern "C" {
 #else
 #define INI_DSN "Elasticsearch30"
 #endif /* UNICODE_SUPPORT */
-
-#define INI_SERVER "host"
+    
+#define INI_HOST "host"
+#define INI_SERVER "server"
 #define INI_PORT "port"
 #define INI_USERNAME "user"    
 #define INI_USERNAME_ABBR "UID"        

--- a/src/elasticodbc/dlg_specific.h
+++ b/src/elasticodbc/dlg_specific.h
@@ -53,8 +53,10 @@ extern "C" {
 
 #define INI_SERVER "host"
 #define INI_PORT "port"
-#define INI_USERNAME "user"        
-#define INI_PASSWORD "password"  
+#define INI_USERNAME "user"    
+#define INI_USERNAME_ABBR "UID"        
+#define INI_PASSWORD "password"        
+#define INI_PASSWORD_ABBR "PWD"  
 #define INI_AUTH_MODE "auth"
 #define INI_REGION "region" 
 #define INI_SSL_USE "useSSL"  


### PR DESCRIPTION
Issue #6 

Added support for user and password abbreviations (UID/PWD)
Added support for host instead of server and updated defines to match names properly
Added unit test to validate that these connection string changes work

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.