### PR TITLE
Align connection tests with rest of test suite

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,7 +77,7 @@ add_compile_definitions		(	_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING
 								_MBCS
 								_CRT_SECURE_NO_DEPRECATE	
 								_USRDLL	
-								USE_SSL					
+								# USE_SSL					
 							)
 
 # Platform specific compiler definitions

--- a/src/IntegrationTests/ITODBCHelper/it_odbc_helper.h
+++ b/src/IntegrationTests/ITODBCHelper/it_odbc_helper.h
@@ -56,7 +56,9 @@ std::wstring conn_string = []() {
     return temp;
 }();
 
-void AllocConnection(SQLTCHAR* connection_string, SQLHDBC* db_connection,
+void AllocConnection(SQLHDBC* db_connection, bool throw_on_error,
+                     bool log_diag);
+void ITDriverConnect(SQLTCHAR* connection_string, SQLHDBC* db_connection,
                      bool throw_on_error, bool log_diag);
 void AllocStatement(SQLTCHAR* connection_string, SQLHDBC* db_connection,
                     SQLHSTMT* h_statement, bool throw_on_error, bool log_diag);

--- a/src/IntegrationTests/ITODBCInfo/test_odbc_info.cpp
+++ b/src/IntegrationTests/ITODBCInfo/test_odbc_info.cpp
@@ -29,7 +29,7 @@ class TestSQLGetInfo : public testing::Test {
     }
 
     void SetUp() {
-        AllocConnection((SQLTCHAR*)conn_string.c_str(), &m_conn, true, true);
+        ITDriverConnect((SQLTCHAR*)conn_string.c_str(), &m_conn, true, true);
     }
 
     void TearDown() {
@@ -110,21 +110,21 @@ int Ver1GEVer2(std::wstring ver_1_str, std::wstring ver_2_str) {
         SQLSMALLINT string_length_ptr;                                    \
         SQLRETURN ret =                                                   \
             SQLGetInfo(m_conn, info_type, &info_value_ptr,                \
-                       sizeof(info_value_ptr), &string_length_ptr);   \
+                       sizeof(info_value_ptr), &string_length_ptr);       \
         LogAnyDiagnostics(SQL_HANDLE_DBC, m_conn, ret);                   \
         EXPECT_EQ((size_t)info_value_ptr, (size_t)expected_value);        \
     }
 
 // Test template for SQLGetInfo
-#define TEST_SQL_GET_INFO_UINT16(test_name, info_type, expected_value)  \
-    TEST_F(TestSQLGetInfo, test_name) {                                 \
-        SQLUSMALLINT info_value_ptr;                                    \
-        SQLSMALLINT string_length_ptr;                                  \
-        SQLRETURN ret =                                                 \
-            SQLGetInfo(m_conn, info_type, &info_value_ptr,              \
-                       sizeof(info_value_ptr), &string_length_ptr); \
-        LogAnyDiagnostics(SQL_HANDLE_DBC, m_conn, ret);                 \
-        EXPECT_EQ(info_value_ptr, expected_value);                      \
+#define TEST_SQL_GET_INFO_UINT16(test_name, info_type, expected_value) \
+    TEST_F(TestSQLGetInfo, test_name) {                                \
+        SQLUSMALLINT info_value_ptr;                                   \
+        SQLSMALLINT string_length_ptr;                                 \
+        SQLRETURN ret =                                                \
+            SQLGetInfo(m_conn, info_type, &info_value_ptr,             \
+                       sizeof(info_value_ptr), &string_length_ptr);    \
+        LogAnyDiagnostics(SQL_HANDLE_DBC, m_conn, ret);                \
+        EXPECT_EQ(info_value_ptr, expected_value);                     \
     }
 
 /////////////////


### PR DESCRIPTION
*Issue #, if available:* #30 

*Description of changes:*
* align connection tests with other test suites
* remove TODO and update tests that are now returning SQL_SUCCESS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.