### PR TITLE
Fix log output dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The following are the driver options that can be configured using a DSN or conne
 | `LogLevel` | Severity level for driver logs. | one of `ES_OFF`, `ES_FATAL`, `ES_ERROR`, `ES_INFO`, `ES_DEBUG`, `ES_TRACE`, `ES_ALL` | `ES_WARNING` |
 | `LogOutput` | Location for storing driver logs. | string | WIN: `C:\`, MAC: `/tmp` |
 
+Administrative privileges are required to change the value of logging options.
+
 ## Download and Installation
 
 The driver will be available through standard open source repositories for installers.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The following are the driver options that can be configured using a DSN or conne
 | `LogLevel` | Severity level for driver logs. | one of `ES_OFF`, `ES_FATAL`, `ES_ERROR`, `ES_INFO`, `ES_DEBUG`, `ES_TRACE`, `ES_ALL` | `ES_WARNING` |
 | `LogOutput` | Location for storing driver logs. | string | WIN: `C:\`, MAC: `/tmp` |
 
-Administrative privileges are required to change the value of logging options.
+**NOTE:** Administrative privileges are required to change the value of logging options.
 
 ## Download and Installation
 

--- a/src/elasticodbc/dlg_wingui.c
+++ b/src/elasticodbc/dlg_wingui.c
@@ -246,8 +246,11 @@ LRESULT logOptionsProc(HWND hdlg, UINT wMsg, WPARAM wParam, LPARAM lParam) {
                             break;
                     }
                     setGlobalCommlog(ci->drivers.loglevel);
+                    setGlobalDebug(ci->drivers.loglevel);
+                    writeGlobalLogs();
                     GetDlgItemText(hdlg, IDC_LOG_PATH, ci->drivers.output_dir,
                                    sizeof(ci->drivers.output_dir));
+                    setLogDir(ci->drivers.output_dir);
                 }
 
                 case IDCANCEL:

--- a/src/elasticodbc/drvconn.c
+++ b/src/elasticodbc/drvconn.c
@@ -105,7 +105,6 @@ dconn_DoDialog(HWND hwnd, ConnInfo *ci) {
 
 LRESULT CALLBACK dconn_FDriverConnectProc(HWND hdlg, UINT wMsg, WPARAM wParam,
                                           LPARAM lParam) {
-    MYLOG(ES_DEBUG, "dconn_FDriverConnectProc\n");
     ConnInfo *ci;
 
     switch (wMsg) {

--- a/src/elasticodbc/drvconn.c
+++ b/src/elasticodbc/drvconn.c
@@ -105,6 +105,7 @@ dconn_DoDialog(HWND hwnd, ConnInfo *ci) {
 
 LRESULT CALLBACK dconn_FDriverConnectProc(HWND hdlg, UINT wMsg, WPARAM wParam,
                                           LPARAM lParam) {
+    MYLOG(ES_DEBUG, "dconn_FDriverConnectProc\n");
     ConnInfo *ci;
 
     switch (wMsg) {

--- a/src/elasticodbc/es_driver_connect.cpp
+++ b/src/elasticodbc/es_driver_connect.cpp
@@ -181,7 +181,7 @@ static SQLRETURN SetupConnString(const SQLCHAR *conn_str_in,
 
     //This will be used to restore the log output dir fetched from connection string
     //Since getDSNinfo overrides all available connection attributes
-    std::string conn_log_dir(ci->drivers.output_dir);
+    std::string conn_string_log_dir(ci->drivers.output_dir);
 
     // If the ConnInfo in the hdbc is missing anything, this function will fill
     // them in from the registry (assuming of course there is a DSN given -- if
@@ -199,9 +199,9 @@ static SQLRETURN SetupConnString(const SQLCHAR *conn_str_in,
     //Sets log output dir to path retrived from connection string
     //If connection string doesn't have log path then takes value from DSN
     //If connection string & DSN both doesn't include log path then takes default value
-    if (!conn_log_dir.empty()) {
-        setLogDir(conn_log_dir.c_str());
-        conn_log_dir.clear();
+    if (!conn_string_log_dir.empty()) {
+        setLogDir(conn_string_log_dir.c_str());
+        conn_string_log_dir.clear();
     } else {
         setLogDir(ci->drivers.output_dir);
     }

--- a/src/elasticodbc/es_driver_connect.cpp
+++ b/src/elasticodbc/es_driver_connect.cpp
@@ -179,6 +179,10 @@ static SQLRETURN SetupConnString(const SQLCHAR *conn_str_in,
         return SQL_ERROR;
     }
 
+    //This will be used to restore the log output dir fetched from connection string
+    //Since getDSNinfo overrides all available connection attributes
+    std::string conn_log_dir(ci->drivers.output_dir);
+
     // If the ConnInfo in the hdbc is missing anything, this function will fill
     // them in from the registry (assuming of course there is a DSN given -- if
     // not, it does nothing!)
@@ -192,6 +196,16 @@ static SQLRETURN SetupConnString(const SQLCHAR *conn_str_in,
     }
     logs_on_off(1, ci->drivers.loglevel, ci->drivers.loglevel);
 
+    //Sets log output dir to path retrived from connection string
+    //If connection string doesn't have log path then takes value from DSN
+    //If connection string & DSN both doesn't include log path then takes default value
+    if (!conn_log_dir.empty()) {
+        setLogDir(conn_log_dir.c_str());
+        conn_log_dir.clear();
+    } else {
+        setLogDir(ci->drivers.output_dir);
+    }
+    InitializeLogging();
     return SQL_SUCCESS;
 }
 

--- a/src/elasticodbc/mylog.c
+++ b/src/elasticodbc/mylog.c
@@ -482,9 +482,10 @@ int writeGlobalLogs() {
 
 void logInstallerError(int ret, const char *dir) {
     DWORD err = (DWORD)ret;
-    char msg[SQL_MAX_MESSAGE_LENGTH];
+    char msg[SQL_MAX_MESSAGE_LENGTH] = "";
+    msg[0] = '\0';
     ret = SQLInstallerError(1, &err, msg, sizeof(msg), NULL);
-    if (msg)
+    if (msg[0] != '\0')
         MYLOG(ES_DEBUG, "Dir= %s ErrorMsg = %s\n", dir, msg);
 }
 


### PR DESCRIPTION
*Issue #48*

*Description of changes:*
- Updates the log output directory
- The connection string has the highest preference.
- If the connection string doesn't have a log path then the value is taken from DSN.
- When connection string & DSN, don't have value for log path then the default value is used.
- Tested with Integration tests
- Tested with Tableau DSN & Driver options
- Administrative privileges are required to change the value of logging options.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
