### PR TITLE
Remove old driver files before installing Mac driver

### DIFF
--- a/src/installer/CMakeLists.txt
+++ b/src/installer/CMakeLists.txt
@@ -93,10 +93,11 @@ cpack_add_component(Resources
 
 # Install driver files
 install(TARGETS odfesqlodbc DESTINATION bin COMPONENT "Driver")
-if(APPLE)
-    install(FILES "${PROJECT_ROOT}/bin64/dsn_installer" DESTINATION bin COMPONENT "Driver")
-    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/remove-odfe-dsn.sh" DESTINATION bin COMPONENT "Driver")
-endif()
+# TODO: look into DSN Installer failure
+# if(APPLE)
+#     install(FILES "${PROJECT_ROOT}/bin64/dsn_installer" DESTINATION bin COMPONENT "Driver")
+#     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/remove-odfe-dsn.sh" DESTINATION bin COMPONENT "Driver")
+# endif()
 
 # Install documentation files
 install(FILES "${PROJECT_ROOT}/README.md" DESTINATION doc COMPONENT "Docs")

--- a/src/installer/postinstall
+++ b/src/installer/postinstall
@@ -3,6 +3,13 @@
 PKG_INSTALL_DIR=/Applications
 FINAL_INSTALL_DIR=/usr/local/lib/odfe-sql-odbc
 
+# Remove install directory if it already exists
+if [ -d "${FINAL_INSTALL_DIR}" ]; then
+    # Fail if FINAL_INSTALL_DIR is not set for whatever reason
+    if [ -z ${FINAL_INSTALL_DIR} ]; then exit 1; fi
+    rm -rf ${FINAL_INSTALL_DIR}
+fi
+
 # Move PKG installed folders to intended install directory
 mkdir -p ${FINAL_INSTALL_DIR}
 mv ${PKG_INSTALL_DIR}/bin ${FINAL_INSTALL_DIR}/bin


### PR DESCRIPTION
*Issue #, if available:* #113 

*Description of changes:*
This will remove old driver files from the user's system if they already exist, before installing the new files. This will prevent the driver from failing on a re-install.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
