### PR TITLE
Save cluster name as current catalog name

### DIFF
--- a/src/odfesqlodbc/connection.c
+++ b/src/odfesqlodbc/connection.c
@@ -655,8 +655,7 @@ void CC_log_error(const char *func, const char *desc,
 }
 
 const char *CurrCat(const ConnectionClass *conn) {
-    UNUSED(conn);
-    return NULL;
+    return conn->cluster_name;
 }
 
 const char *CurrCatString(const ConnectionClass *conn) {

--- a/src/odfesqlodbc/es_communication.h
+++ b/src/odfesqlodbc/es_communication.h
@@ -64,6 +64,7 @@ class ESCommunication {
     bool SetClientEncoding(std::string& encoding);
     bool IsSQLPluginInstalled(const std::string& plugin_response);
     std::string GetServerVersion();
+    std::string GetClusterName();
     std::shared_ptr< Aws::Http::HttpResponse > IssueRequest(
         const std::string& endpoint, const Aws::Http::HttpMethod request_type,
         const std::string& content_type, const std::string& query,

--- a/src/odfesqlodbc/es_connection.cpp
+++ b/src/odfesqlodbc/es_connection.cpp
@@ -144,6 +144,9 @@ int LIBES_connect(ConnectionClass *self) {
     std::string server_version = GetServerVersion(esconn);
     STRCPY_FIXED(self->es_version, server_version.c_str());
 
+    std::string cluster_name = GetClusterName(esconn);
+    STRCPY_FIXED(self->cluster_name, cluster_name.c_str());
+
     self->esconn = (void *)esconn;
     return 1;
 }

--- a/src/odfesqlodbc/es_connection.h
+++ b/src/odfesqlodbc/es_connection.h
@@ -282,6 +282,7 @@ struct ConnectionClass_ {
     DriverToDataSourceProc DriverToDataSource;
     char transact_status;             /* Is a transaction is currently
                                        * in progress */
+    char cluster_name[MAX_INFO_STRING];
     char es_version[MAX_INFO_STRING]; /* Version of Elasticsearch driver
                                        * we're connected to -
                                        * DJP 25-1-2001 */

--- a/src/odfesqlodbc/es_helper.cpp
+++ b/src/odfesqlodbc/es_helper.cpp
@@ -63,6 +63,12 @@ std::string GetServerVersion(void* es_conn) {
                : "";
 }
 
+std::string GetClusterName(void* es_conn) {
+    return es_conn
+               ? static_cast< ESCommunication* >(es_conn)->GetClusterName()
+               : "";
+}
+
 void* InitializeESConn() {
     return new ESCommunication();
 }

--- a/src/odfesqlodbc/es_helper.h
+++ b/src/odfesqlodbc/es_helper.h
@@ -28,6 +28,7 @@ void ESClearResult(ESResult* es_result);
 void* ESConnectDBParams(runtime_options& rt_opts, int expand_dbname,
                         unsigned int option_count);
 std::string GetServerVersion(void* es_conn);
+std::string GetClusterName(void* es_conn);
 std::string GetErrorMsg(void* es_conn);
 
 // C Interface

--- a/src/odfesqlodbc/es_info.cpp
+++ b/src/odfesqlodbc/es_info.cpp
@@ -476,8 +476,13 @@ void SetTableTuples(QResultClass *res, const TableResultSet res_type,
     // General case
     if (res_type == TableResultSet::All) {
         RETCODE result = SQL_NO_DATA_FOUND;
-        while (SQL_SUCCEEDED(result = ESAPI_Fetch(tbl_stmt)))
+        while (SQL_SUCCEEDED(result = ESAPI_Fetch(tbl_stmt))) {
+            if (bind_tbl[TABLES_TABLE_TYPE]->AsString() == "BASE TABLE") {
+                std::string table("TABLE");
+                bind_tbl[TABLES_TABLE_TYPE]->UpdateData(&table, table.size());
+            }
             AssignData(res, bind_tbl);
+        }
         CheckResult(result);
     } else if (res_type == TableResultSet::TableLookUp) {
         // Get accepted table types

--- a/src/odfesqlodbc/info.c
+++ b/src/odfesqlodbc/info.c
@@ -457,7 +457,7 @@ RETCODE SQL_API ESAPI_GetInfo(HDBC hdbc, SQLUSMALLINT fInfoType,
             break;
 
         case SQL_OWNER_TERM: /* ODBC 1.0 */
-            p = "schema";
+            p = "";
             break;
 
         case SQL_OWNER_USAGE: /* ODBC 2.0 */
@@ -495,7 +495,7 @@ RETCODE SQL_API ESAPI_GetInfo(HDBC hdbc, SQLUSMALLINT fInfoType,
             break;
 
         case SQL_QUALIFIER_TERM: /* ODBC 1.0 */
-                p = "catalog";
+            p = "cluster";
             break;
 
         case SQL_QUALIFIER_USAGE: /* ODBC 2.0 */


### PR DESCRIPTION
*Issue #, if available:* #139 

*Description of changes:*
save cluster name as current catalog for ODBC interactions with Excel
- change term names appropriately
- change table term for SQLTables ALL Types query

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
