### PR TITLE
Remove columns from result which are not returned by SELECT * query but returned by DESCRIBE query

### DIFF
--- a/src/IntegrationTests/ITODBCCatalog/test_odbc_catalog.cpp
+++ b/src/IntegrationTests/ITODBCCatalog/test_odbc_catalog.cpp
@@ -71,7 +71,7 @@ typedef struct bind_info {
 
 // Column test constants and macro
 const std::vector< std::string > flights_column_name = {
-    "FlightNum",      "Origin",         "OriginLocation",  "DestLocation",
+    "FlightNum",      "Origin",   
     "FlightDelay",    "DistanceMiles",  "FlightTimeMin",   "OriginWeather",
     "dayOfWeek",      "AvgTicketPrice", "Carrier",         "FlightDelayMin",
     "OriginRegion",   "DestAirportID",  "FlightDelayType", "timestamp",
@@ -79,7 +79,7 @@ const std::vector< std::string > flights_column_name = {
     "OriginCityName", "DestWeather",    "OriginCountry",   "DestCountry",
     "DestRegion",     "DestCityName",   "OriginAirportID"};
 const std::vector< std::string > flights_data_type = {
-    "keyword", "keyword", "geo_point", "geo_point", "boolean", "float",
+    "keyword", "keyword",  "boolean", "float",
     "float",   "keyword", "integer",   "float",     "keyword", "integer",
     "keyword", "keyword", "keyword",   "date",      "keyword", "keyword",
     "boolean", "float",   "keyword",   "keyword",   "keyword", "keyword",
@@ -404,7 +404,7 @@ TEST_F(TestSQLColumns, FlightsValidation) {
         }
         column_idx++;
     }
-    EXPECT_EQ(column_idx, static_cast< size_t >(27));
+    EXPECT_EQ(column_idx, static_cast< size_t >(25));
 }
 
 // We expect an empty result set for PrimaryKeys and ForeignKeys

--- a/src/odfesqlodbc/connection.c
+++ b/src/odfesqlodbc/connection.c
@@ -655,8 +655,15 @@ void CC_log_error(const char *func, const char *desc,
 }
 
 const char *CurrCat(const ConnectionClass *conn) {
+    // Keeping this NULL since it's required for getting list of tables in Microsoft Excel with ODBC Connection mode.
+    // This causes error in Data Connection wizard mode but data connection wizard sends query with catalog.table_name which fails.
+    // So setting this to NULL will enable more functionality
     UNUSED(conn);
     return NULL;
+
+    // Change this to following return value when found a solution which works with 
+    // ODBC and Data Connection wizard in Microsoft Excel
+    // return conn->cluster_name;
 }
 
 const char *CurrCatString(const ConnectionClass *conn) {

--- a/src/odfesqlodbc/connection.c
+++ b/src/odfesqlodbc/connection.c
@@ -655,7 +655,8 @@ void CC_log_error(const char *func, const char *desc,
 }
 
 const char *CurrCat(const ConnectionClass *conn) {
-    return conn->cluster_name;
+    UNUSED(conn);
+    return NULL;
 }
 
 const char *CurrCatString(const ConnectionClass *conn) {

--- a/src/odfesqlodbc/es_communication.cpp
+++ b/src/odfesqlodbc/es_communication.cpp
@@ -407,6 +407,70 @@ bool ESCommunication::EstablishConnection() {
     return false;
 }
 
+std::vector< std::string > ESCommunication::GetColumnsWithSelectQuery(const std::string table_name) {
+    std::vector< std::string > list_of_column;
+    if (table_name.empty()) {
+        m_error_message = "Query is NULL";
+        LogMsg(ES_ERROR, m_error_message.c_str());
+        //return list_of_column;
+    } else if (!m_http_client) {
+        m_error_message = "Unable to connect. Please try connecting again.";
+        LogMsg(ES_ERROR, m_error_message.c_str());
+        //return -1;
+    }
+
+    // Prepare query
+    std::string query = "SELECT * FROM " + table_name;
+    std::string msg = "Attempting to execute a query \"" + query + "\"";
+    LogMsg(ES_DEBUG, msg.c_str());
+
+    // Issue request
+    std::shared_ptr< Aws::Http::HttpResponse > response =
+        IssueRequest(SQL_ENDPOINT_FORMAT_JDBC, Aws::Http::HttpMethod::HTTP_POST,
+                     ctype, query);
+
+    // Validate response
+    if (response == nullptr) {
+        m_error_message =
+            "Failed to receive response from query. "
+            "Received NULL response.";
+        LogMsg(ES_ERROR, m_error_message.c_str());
+        //return list_of_column;
+    }
+
+    // Convert body from Aws IOStream to string
+    std::unique_ptr< ESResult > result = std::make_unique< ESResult >();
+    AwsHttpResponseToString(response, result->result_json);
+
+    // If response was not valid, set error
+    if (response->GetResponseCode() != Aws::Http::HttpResponseCode::OK) {
+        m_error_message =
+            "Http response code was not OK. Code received: "
+            + std::to_string(static_cast< long >(response->GetResponseCode()))
+            + ".";
+        if (response->HasClientError())
+            m_error_message +=
+                " Client error: '" + response->GetClientErrorMessage() + "'.";
+        if (!result->result_json.empty()) {
+            m_error_message +=
+                " Response error: '" + result->result_json + "'.";
+        }
+        LogMsg(ES_ERROR, m_error_message.c_str());
+        return list_of_column;
+    }
+
+    GetJsonSchema(*result);
+
+    rabbit::array schema_array = result->es_result_doc["schema"];
+    for (rabbit::array::iterator it = schema_array.begin();
+         it != schema_array.end(); ++it) {
+        std::string column_name = it->at("name").as_string();
+        list_of_column.push_back(column_name);
+    }
+
+    return list_of_column;
+}
+
 int ESCommunication::ExecDirect(const char* query, const char* fetch_size_) {
     if (!query) {
         m_error_message = "Query is NULL";

--- a/src/odfesqlodbc/es_communication.cpp
+++ b/src/odfesqlodbc/es_communication.cpp
@@ -412,11 +412,7 @@ std::vector< std::string > ESCommunication::GetColumnsWithSelectQuery(const std:
     if (table_name.empty()) {
         m_error_message = "Query is NULL";
         LogMsg(ES_ERROR, m_error_message.c_str());
-        //return list_of_column;
-    } else if (!m_http_client) {
-        m_error_message = "Unable to connect. Please try connecting again.";
-        LogMsg(ES_ERROR, m_error_message.c_str());
-        //return -1;
+        return list_of_column;
     }
 
     // Prepare query
@@ -435,7 +431,7 @@ std::vector< std::string > ESCommunication::GetColumnsWithSelectQuery(const std:
             "Failed to receive response from query. "
             "Received NULL response.";
         LogMsg(ES_ERROR, m_error_message.c_str());
-        //return list_of_column;
+        return list_of_column;
     }
 
     // Convert body from Aws IOStream to string

--- a/src/odfesqlodbc/es_communication.cpp
+++ b/src/odfesqlodbc/es_communication.cpp
@@ -416,7 +416,7 @@ std::vector< std::string > ESCommunication::GetColumnsWithSelectQuery(const std:
     }
 
     // Prepare query
-    std::string query = "SELECT * FROM " + table_name;
+    std::string query = "SELECT * FROM " + table_name + " LIMIT 0";
     std::string msg = "Attempting to execute a query \"" + query + "\"";
     LogMsg(ES_DEBUG, msg.c_str());
 

--- a/src/odfesqlodbc/es_communication.h
+++ b/src/odfesqlodbc/es_communication.h
@@ -74,6 +74,7 @@ class ESCommunication {
         std::string& output);
     void SendCloseCursorRequest(const std::string& cursor);
     void StopResultRetrieval();
+    std::vector<std::string> GetColumnsWithSelectQuery(const std::string table_name);
 
    private:
     void InitializeConnection();

--- a/src/odfesqlodbc/es_helper.cpp
+++ b/src/odfesqlodbc/es_helper.cpp
@@ -114,6 +114,11 @@ void ESStopRetrieval(void* es_conn) {
      static_cast< ESCommunication* >(es_conn)->StopResultRetrieval();
 }
 
+std::vector< std::string > ESGetColumnsWithSelectQuery(void* es_conn,
+                                                       const std::string table_name) {
+    return static_cast< ESCommunication* >(es_conn)->GetColumnsWithSelectQuery(table_name);
+}
+
 // This class provides a cross platform way of entering critical sections
 class CriticalSectionHelper {
    public:

--- a/src/odfesqlodbc/es_helper.h
+++ b/src/odfesqlodbc/es_helper.h
@@ -30,6 +30,8 @@ void* ESConnectDBParams(runtime_options& rt_opts, int expand_dbname,
 std::string GetServerVersion(void* es_conn);
 std::string GetClusterName(void* es_conn);
 std::string GetErrorMsg(void* es_conn);
+std::vector< std::string > ESGetColumnsWithSelectQuery(void* es_conn,
+                                                       const std::string table_name);
 
 // C Interface
 extern "C" {


### PR DESCRIPTION
*Issue #141*

*Description of changes:*
* Added method to get a list of columns returned by SELECT * query. Only these columns will be reported to an application while sending a list of columns in that table.
* Tested with all integration tests, Tableau & Microsoft Excel 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
